### PR TITLE
fix(smu): Invalid school semester assumptions (#11)

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,8 @@
 export const DATE_FORMAT = 'yyyy-MM-DD';
 export const YEARS_TO_GENERATE = 10;
+
+export enum SMU_ACADEMIC_PERIOD_WEEKS {
+  STUDY = 15,
+  VACATION_1 = 6,
+  VACATION_2 = 16,
+}

--- a/src/uni/SMU.ts
+++ b/src/uni/SMU.ts
@@ -102,6 +102,19 @@ function generateTerm(start: Moment, label: string, vacationWeekCount: number) {
   return { term, end: tempEnd };
 }
 
+function getAcademicCalendarYearStartDate(monthMoment: Moment) {
+  let start = nthDayOfMonth(monthMoment, Day.Mon, 3);
+
+  // ASSUMPTION: SMU academic year start on the 4th week of august
+  // if day of month is more than 20, it falls on the 3rd week instead
+  const dayOfMonth = Number(start.format('D'));
+  if (dayOfMonth > 20) {
+    start = nthDayOfMonth(monthMoment, Day.Mon, 4);
+  }
+
+  return start;
+}
+
 function getVacationWeekCount(termNum: number) {
   switch (termNum) {
     case 1: {
@@ -115,8 +128,22 @@ function getVacationWeekCount(termNum: number) {
 
 export default function SMU() {
   const terms: App.Term[] = [];
+  const academicYearsStartDate: Moment[] = [];
 
   const currentYear = moment().year();
+
+  // Next: consider use case of 17th week vacation
+
+  // Generate academic school term start dates for the next X years
+  for (let yearIndex = -1; yearIndex < YEARS_TO_GENERATE; yearIndex++) {
+    const augustMoment = moment()
+      .set('year', currentYear + yearIndex)
+      .set('month', 7)
+      .set('date', 1);
+
+    const start = getAcademicCalendarYearStartDate(augustMoment);
+    academicYearsStartDate.push(start);
+  }
 
   // Generate for the next X years
   for (let yearIndex = -1; yearIndex < YEARS_TO_GENERATE; yearIndex++) {

--- a/src/uni/SMU.ts
+++ b/src/uni/SMU.ts
@@ -104,12 +104,14 @@ function generateTerm(start: Moment, label: string, vacationWeekCount: number) {
 
 function getAcademicCalendarYearStartDate(monthMoment: Moment) {
   let start = nthDayOfMonth(monthMoment, Day.Mon, 3);
-
-  // ASSUMPTION: SMU academic year start on the 4th week of august
-  // if day of month is more than 20, it falls on the 3rd week instead
   const dayOfMonth = Number(start.format('D'));
+
+  /**
+   * ASSUMPTION: SMU academic year generally start on the 3rd Monday of August
+   * If the day of month > 20, it will fall on the 2nd Monday instead
+   */
   if (dayOfMonth > 20) {
-    start = nthDayOfMonth(monthMoment, Day.Mon, 4);
+    start = nthDayOfMonth(monthMoment, Day.Mon, 2);
   }
 
   return start;

--- a/src/uni/SMU.ts
+++ b/src/uni/SMU.ts
@@ -150,7 +150,7 @@ export default function SMU() {
 
       // Consider Term 2 Vacations cases with more than 16 weeks of break
       // Calculate by comparing start date of next academic year
-      if (termIndex + 1 > 1) {
+      if (termIndex + 1 === 2) {
         const numOfWeeksTerm2 = upcomingAcademicStart.diff(start, 'weeks');
         vacationWeekCount =
           numOfWeeksTerm2 - SMU_ACADEMIC_PERIOD_WEEKS.STUDY - 1;


### PR DESCRIPTION
Issue #11 https://github.com/alphatrl/classmaid/issues/98

## Purpose

This PR improves the start date calculation of the SMU academic school semester by falling back to the 2nd Monday of the month of August if the day of the month is too high (above 20). 

It also improves on Term 2 vacation weeks calculation where there are some school semesters with 17 weeks instead of the usual 16 weeks (`AY2023-24`, `AY2028-29`).